### PR TITLE
Add support for selection of projects and scala versions

### DIFF
--- a/src/main/contraband/input.contra
+++ b/src/main/contraband/input.contra
@@ -1,0 +1,13 @@
+package ch.epfl.scala
+@target(Scala)
+@codecPackage("ch.epfl.scala")
+@fullCodec("JsonProtocol")
+
+## Input of the githubSubmitDependencyGraph command
+type SubmitInput {
+  ## A set of projects. An empty array means all projects.
+  projects: [String]
+
+  ## A set of Scala versions. An empty array means all scala versions.
+  scalaVersions: [String]
+}

--- a/src/main/scala/ch/epfl/scala/SubmitDependencyGraph.scala
+++ b/src/main/scala/ch/epfl/scala/SubmitDependencyGraph.scala
@@ -1,0 +1,172 @@
+package ch.epfl.scala
+
+import java.nio.charset.StandardCharsets
+import java.time.Instant
+
+import scala.concurrent.Await
+import scala.concurrent.duration.Duration
+import scala.util.Properties
+import scala.util.Try
+
+import ch.epfl.scala.GithubDependencyGraphPlugin.autoImport._
+import ch.epfl.scala.JsonProtocol._
+import ch.epfl.scala.githubapi.JsonProtocol._
+import ch.epfl.scala.githubapi._
+import gigahorse.HttpClient
+import gigahorse.support.okhttp.Gigahorse
+import sbt.BasicCommandStrings._
+import sbt._
+import sbt.internal.util.complete._
+import sjsonnew.shaded.scalajson.ast.unsafe.JValue
+import sjsonnew.support.scalajson.unsafe.{Parser => JsonParser, _}
+
+object SubmitDependencyGraph {
+  val Submit = "githubSubmitDependencyGraph"
+  val usage: String = s"""$Submit {"projects":[], "scalaVersions":[]}"""
+  val brief = "Submit the dependency graph to Github Dependency API."
+  val detail = "Submit the dependency graph of a set of projects and scala versions to Github Dependency API"
+
+  val SubmitInternal: String = s"${Submit}Internal"
+  val internalOnly = "internal usage only"
+
+  val commands: Seq[Command] = Seq(
+    Command(Submit, (usage, brief), detail)(inputParser)(submit),
+    Command.command(SubmitInternal, internalOnly, internalOnly)(submitInternal)
+  )
+
+  private lazy val http: HttpClient = Gigahorse.http(Gigahorse.config)
+
+  private def inputParser(state: State): Parser[SubmitInput] =
+    Parsers.any.*.map { raw =>
+      JsonParser
+        .parseFromString(raw.mkString)
+        .flatMap(Converter.fromJson[SubmitInput])
+        .get
+    }
+
+  private def submit(state: State, input: SubmitInput): State = {
+    checkGithubEnv() // fail fast if the Github CI environment is incomplete
+    val projectRefs = getProjectRefs(state, input)
+    val scalaVersions = getScalaVersions(state, input, projectRefs)
+    val initState = state
+      .put(githubManifestsKey, Map.empty[String, Manifest])
+      .put(githubProjectsKey, projectRefs)
+
+    val storeAllManifests = scalaVersions.toList.flatMap { scalaVersion =>
+      Seq(s"++$scalaVersion", githubStoreDependencyManifests.key.label)
+    }
+    val commands =
+      StashOnFailure ::
+        storeAllManifests :::
+        SubmitInternal ::
+        FailureWall ::
+        PopOnFailure ::
+        Nil
+    commands ::: initState
+  }
+
+  private def submitInternal(state: State): State = {
+    val snapshot = githubDependencySnapshot(state)
+    val url = new URL(s"${githubApiUrl()}/repos/${githubRepository()}/dependency-graph/snapshots")
+
+    val snapshotJson = CompactPrinter(Converter.toJsonUnsafe(snapshot))
+    val request = Gigahorse
+      .url(url.toString)
+      .post(snapshotJson, StandardCharsets.UTF_8)
+      .addHeaders(
+        "Content-Type" -> "application/json",
+        "Authorization" -> s"token $githubToken"
+      )
+
+    state.log.info(s"Submiting dependency snapshot to $url")
+    val response = Await.result(http.run(request), Duration.Inf)
+    val result = for {
+      httpResp <- Try(Await.result(http.run(request), Duration.Inf))
+      jsonResp <- JsonParser.parseFromByteBuffer(httpResp.bodyAsByteBuffer)
+      response <- Converter.fromJson[SnapshotResponse](jsonResp)
+    } yield new URL(url, response.id.toString)
+
+    result match {
+      case scala.util.Success(result) =>
+        state.log.info(s"Submitted successfully as $result")
+        state
+      case scala.util.Failure(cause) =>
+        throw new MessageOnlyException(
+          s"Failed to submit the dependency snapshot because of ${cause.getClass.getName}: ${cause.getMessage}"
+        )
+    }
+  }
+
+  private def getProjectRefs(state: State, input: SubmitInput): Seq[ProjectRef] = {
+    val loadedBuild = state.setting(Keys.loadedBuild)
+    val allProjectRefs = loadedBuild.allProjectRefs.map(_._1)
+    val projectFilter = input.projects.toSet
+    if (projectFilter.isEmpty) allProjectRefs
+    else allProjectRefs.filter(ref => projectFilter.contains(ref.project))
+  }
+
+  private def getScalaVersions(state: State, input: SubmitInput, projectRefs: Seq[ProjectRef]): Seq[String] = {
+    val scalaVersionFilter = input.scalaVersions.toSet
+    val allScalaVersions = projectRefs
+      .flatMap(projectRef => state.setting(projectRef / Keys.crossScalaVersions))
+      .distinct
+    if (scalaVersionFilter.isEmpty) allScalaVersions
+    else allScalaVersions.filter(scalaVersionFilter.contains)
+  }
+
+  private def githubDependencySnapshot(state: State): DependencySnapshot = {
+    val detector = DetectorMetadata(
+      SbtGithubDependencyGraph.name,
+      SbtGithubDependencyGraph.homepage.map(_.toString).getOrElse(""),
+      SbtGithubDependencyGraph.version
+    )
+    val scanned = Instant.now
+    val manifests = state.get(githubManifestsKey).get
+    DependencySnapshot(
+      0,
+      githubJob(),
+      githubSha(),
+      githubRef(),
+      detector,
+      Map.empty[String, JValue],
+      manifests,
+      scanned.toString
+    )
+  }
+
+  private def githubJob(): Job = {
+    val correlator = s"${githubJobName()}_${githubWorkflow()}"
+    val id = githubRunId
+    val html_url =
+      for {
+        serverUrl <- Properties.envOrNone("$GITHUB_SERVER_URL")
+        repository <- Properties.envOrNone("GITHUB_REPOSITORY")
+      } yield s"$serverUrl/$repository/actions/runs/$id"
+    Job(correlator, id, html_url)
+  }
+
+  private def checkGithubEnv(): Unit = {
+    githubWorkflow()
+    githubJobName()
+    githubRunId()
+    githubSha()
+    githubRef()
+    githubApiUrl()
+    githubRepository()
+    githubToken()
+  }
+
+  private def githubWorkflow(): String = githubCIEnv("GITHUB_WORKFLOW")
+  private def githubJobName(): String = githubCIEnv("GITHUB_JOB")
+  private def githubRunId(): String = githubCIEnv("GITHUB_RUN_ID")
+  private def githubSha(): String = githubCIEnv("GITHUB_SHA")
+  private def githubRef(): String = githubCIEnv("GITHUB_REF")
+  private def githubApiUrl(): String = githubCIEnv("GITHUB_API_URL")
+  private def githubRepository(): String = githubCIEnv("GITHUB_REPOSITORY")
+  private def githubToken(): String = githubCIEnv("GITHUB_TOKEN")
+
+  private def githubCIEnv(name: String): String =
+    Properties.envOrNone(name).getOrElse {
+      throw new MessageOnlyException(s"Missing environment variable $name. This task must run in a Github Action.")
+    }
+}

--- a/src/sbt-test/dependency-graph/ci-submit/build.sbt
+++ b/src/sbt-test/dependency-graph/ci-submit/build.sbt
@@ -1,30 +1,37 @@
 import scala.util.Properties
+import sbt.internal.util.complete.Parsers._
 
-val checkSubmit = taskKey[Unit]("Check the Github manifest of a project")
+val checkManifests = inputKey[Unit]("Check the number of manifests")
 
 inThisBuild(
   Seq(
     organization := "ch.epfl.scala",
     version := "1.2.0-SNAPSHOT",
     useCoursier := true,
-    scalaVersion := "2.12.15"
+    scalaVersion := "2.12.15",
+    crossScalaVersions := Seq(
+      "2.12.16",
+      "2.13.8",
+      "3.1.3"
+    )
   )
 )
 
-Global / checkSubmit := {
-  val result = submitGithubDependencyGraph.result.value
-  val isCI = Properties.envOrNone("CI").isDefined
-  val isPush = Properties.envOrNone("GITHUB_REF").exists(_.startsWith("refs/heads/"))
-  val logger = streams.value.log
-  result match {
-    case Value(_) => ()
-    case Inc(cause) =>
-      if (isCI && isPush) throw cause
-      else {
-        val firstMessage = Incomplete.allExceptions(cause).head.getMessage
-        logger.info(s"Cannot check submit because: $firstMessage")
-      }
-  }
-}
+val a = project.in(file("a"))
 
-lazy val p1 = project.in(file("p1"))
+val b = project
+  .in(file("b"))
+  .settings(
+    libraryDependencies += "org.typelevel" %% "cats-core" % "2.8.0"
+  )
+
+Global / checkManifests := {
+  val expectedSize: Int = (Space ~> NatBasic).parsed
+  val manifests = state.value.get(githubManifestsKey).getOrElse {
+    throw new MessageOnlyException(s"Not found ${githubManifestsKey.label} attribute")
+  }
+  assert(
+    manifests.size == expectedSize,
+    s"expected $expectedSize manifests, found ${manifests.size}"
+  )
+}

--- a/src/sbt-test/dependency-graph/ci-submit/test
+++ b/src/sbt-test/dependency-graph/ci-submit/test
@@ -1,1 +1,6 @@
-> checkSubmit
+> 'githubSubmitDependencyGraph {}'
+> checkManifests 9
+> 'githubSubmitDependencyGraph {"projects":[], "scalaVersions":["2.13.8"]}'
+> checkManifests 3
+> 'githubSubmitDependencyGraph {"projects":["a"], "scalaVersions":["2.12.16", "3.1.3"]}'
+> checkManifests 2

--- a/src/test/scala/ch/epfl/scala/JsonProtocolTests.scala
+++ b/src/test/scala/ch/epfl/scala/JsonProtocolTests.scala
@@ -1,6 +1,5 @@
-package ch.epfl.scala.githubapi
+package ch.epfl.scala
 
-import ch.epfl.scala.githubapi.JsonProtocol._
 import munit.FunSuite
 import sjsonnew.shaded.scalajson.ast.unsafe.JField
 import sjsonnew.shaded.scalajson.ast.unsafe.JNumber
@@ -8,9 +7,11 @@ import sjsonnew.shaded.scalajson.ast.unsafe.JObject
 import sjsonnew.shaded.scalajson.ast.unsafe.JString
 import sjsonnew.shaded.scalajson.ast.unsafe.JValue
 import sjsonnew.support.scalajson.unsafe.Converter
+import sjsonnew.support.scalajson.unsafe.Parser
 
 class JsonProtocolTests extends FunSuite {
   test("encode metadata") {
+    import ch.epfl.scala.githubapi.JsonProtocol._
     val metadata = Map("key1" -> JString("value1"), "key2" -> JNumber(1))
     val obtained = Converter.toJson(metadata).get
     val expected = JObject(JField("key1", JString("value1")), JField("key2", JNumber(1)))
@@ -18,9 +19,18 @@ class JsonProtocolTests extends FunSuite {
   }
 
   test("decode metadata") {
+    import ch.epfl.scala.githubapi.JsonProtocol._
     val metadata = JObject(JField("key1", JString("value1")), JField("key2", JNumber(1)))
     val obtained = Converter.fromJson[Map[String, JValue]](metadata).get
     val expected = Map("key1" -> JString("value1"), "key2" -> JNumber(1))
+    assertEquals(obtained, expected)
+  }
+
+  test("decode empty input") {
+    import ch.epfl.scala.JsonProtocol._
+    val raw = Parser.parseUnsafe("{}")
+    val obtained = Converter.fromJson[SubmitInput](raw).get
+    val expected = SubmitInput(Vector.empty, Vector.empty)
     assertEquals(obtained, expected)
   }
 }


### PR DESCRIPTION
The `githubSubmitDependencyGraph` is now a command instead of a task. It takes a set of projects and a set of scala versions as input (in a json object) and it submits a snapshot containing the manifests of the specified projects on the specified scala versions.

If the set of projects is empty it submits a snapshot of all projects.
Similarly, if the set of scala versions is empty, it submits a snapshot of all scala versions.