### PR TITLE
Filter manifests on valid Scala versions

### DIFF
--- a/src/sbt-test/dependency-graph/ci-submit/build.sbt
+++ b/src/sbt-test/dependency-graph/ci-submit/build.sbt
@@ -7,31 +7,42 @@ inThisBuild(
   Seq(
     organization := "ch.epfl.scala",
     version := "1.2.0-SNAPSHOT",
-    useCoursier := true,
-    scalaVersion := "2.12.15",
+    scalaVersion := "2.13.8"
+  )
+)
+
+val a = project
+  .in(file("a"))
+  .settings(
+    scalaVersion := "2.13.8",
     crossScalaVersions := Seq(
       "2.12.16",
       "2.13.8",
       "3.1.3"
     )
   )
-)
 
-val a = project.in(file("a"))
-
+// b is not cross-compiled
+// but we should still be able to resolve the manifests of the build on 2.12.16 and 3.1.3
+// this pattern is taken from scalameta/metals where metals, not cross-compiled, depends on mtags
+// which is cross-compiled
 val b = project
   .in(file("b"))
   .settings(
-    libraryDependencies += "org.typelevel" %% "cats-core" % "2.8.0"
+    scalaVersion := "2.13.8"
   )
+  .dependsOn(a)
 
-Global / checkManifests := {
+checkManifests := {
+  val logger = streams.value.log
   val expectedSize: Int = (Space ~> NatBasic).parsed
   val manifests = state.value.get(githubManifestsKey).getOrElse {
     throw new MessageOnlyException(s"Not found ${githubManifestsKey.label} attribute")
   }
+  logger.info(s"found ${manifests.size} manifests")
   assert(
     manifests.size == expectedSize,
     s"expected $expectedSize manifests, found ${manifests.size}"
   )
 }
+checkManifests / aggregate := false

--- a/src/sbt-test/dependency-graph/ci-submit/test
+++ b/src/sbt-test/dependency-graph/ci-submit/test
@@ -1,6 +1,10 @@
 > 'githubSubmitDependencyGraph {}'
-> checkManifests 9
+> checkManifests 5
 > 'githubSubmitDependencyGraph {"projects":[], "scalaVersions":["2.13.8"]}'
 > checkManifests 3
+> 'githubSubmitDependencyGraph {"projects":[], "scalaVersions":["2.12.16", "2.13.8"]}'
+> checkManifests 4
+> 'githubSubmitDependencyGraph {"projects":["a", "b"], "scalaVersions":[]}'
+> checkManifests 4
 > 'githubSubmitDependencyGraph {"projects":["a"], "scalaVersions":["2.12.16", "3.1.3"]}'
 > checkManifests 2


### PR DESCRIPTION
Fixes a bug found in scalameta/metals, where the `metals` project which is not cross-compiled depends on `mtags` which is cross-compiled.